### PR TITLE
fix: remove localtileserver from sepal env

### DIFF
--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -15,4 +15,3 @@ dependencies:
   - pip:
       - sepal_ui==2.22.1
       - git+https://github.com/openforis/earthengine-api.git@v1.1.5rc0#egg=earthengine-api&subdirectory=python
-      - localtileserver<=0.10.0


### PR DESCRIPTION
## Summary
- remove localtileserver from the pip dependencies in sepal_environment.yml
- keep the change scoped to the SEPAL environment used by the deployed app

## Why
localtileserver is causing the SEPAL environment installation to fail for basin-rivers.

## Notes
- test.sepal.io and local SEPAL only pick this up after the branch is pushed and the cron-driven git pull updates the module from origin/master
- prod picks changes from origin/release
